### PR TITLE
Adds HMAC master seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,13 @@
 # IntelliJ IDEA project files
+.project
+.classpath
+.settings
 .idea
 *.iml
 
 # Gradle output
 /.gradle
 /build
+bin
+buildSrc
 /gradle.properties

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -107,6 +107,7 @@ public class KeycardApplet extends Applet {
   private byte[] uid;
   private SecureChannel secureChannel;
 
+  private HMACKey masterSeed;
   private ECPublicKey masterPublic;
   private ECPrivateKey masterPrivate;
   private byte[] masterChainCode;
@@ -172,6 +173,7 @@ public class KeycardApplet extends Applet {
     uid = new byte[UID_LENGTH];
     crypto.random.generateData(uid, (short) 0, UID_LENGTH);
 
+    masterSeed = (HMACKey) KeyBuilder.buildKey(KeyBuilder.TYPE_HMAC, BIP39_SEED_SIZE, false);
     masterPublic = (ECPublicKey) KeyBuilder.buildKey(KeyBuilder.TYPE_EC_FP_PUBLIC, SECP256k1.SECP256K1_KEY_SIZE, false);
     masterPrivate = (ECPrivateKey) KeyBuilder.buildKey(KeyBuilder.TYPE_EC_FP_PRIVATE, SECP256k1.SECP256K1_KEY_SIZE, false);
 
@@ -767,6 +769,7 @@ public class KeycardApplet extends Applet {
     JCSystem.beginTransaction();
     isExtended = true;
 
+    masterSeed.setKey(apduBuffer, (short) ISO7816.OFFSET_CDATA, BIP39_SEED_SIZE);
     masterPrivate.setS(apduBuffer, (short) ISO7816.OFFSET_CDATA, CHAIN_CODE_SIZE);
     privateKey.setS(apduBuffer, (short) ISO7816.OFFSET_CDATA, CHAIN_CODE_SIZE);
 


### PR DESCRIPTION
- [x] Add a master seed object so we can persist the seed for backups

- [x] Save master seed as HMAC key when `generateKey` is called
 
- [ ] Add function to export seed